### PR TITLE
Adding Ulimit Builder object in HostConfig Builder.

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -232,7 +232,8 @@ public class HostConfig {
         Objects.equals(this.cgroupParent, that.cgroupParent) &&
         Objects.equals(this.restartPolicy, that.restartPolicy) &&
         Objects.equals(this.logConfig, that.logConfig) &&
-        Objects.equals(this.ipcMode, that.ipcMode);
+        Objects.equals(this.ipcMode, that.ipcMode) &&
+            Objects.equals(this.ulimits, that.ulimits);
   }
 
   @Override
@@ -241,7 +242,7 @@ public class HostConfig {
                         publishAllPorts, dns, dnsSearch, extraHosts, volumesFrom, capAdd,
                         capDrop, networkMode, securityOpt, devices, memory, memorySwap,
                         cpuShares, cpusetCpus, cpuQuota, cgroupParent, restartPolicy, logConfig,
-                        ipcMode);
+                        ipcMode, ulimits);
   }
 
   @Override
@@ -272,6 +273,7 @@ public class HostConfig {
         .add("restartPolicy", restartPolicy)
         .add("logConfig", logConfig)
         .add("ipcMode", ipcMode)
+            .add("ulimits", ulimits)
         .toString();
   }
 
@@ -789,9 +791,9 @@ public class HostConfig {
       return this;
     }
 
-    public Builder ulimits(final Ulimit... ulmits) {
-      if (ulmits != null && ulmits.length > 0) {
-        this.ulimits = ImmutableList.copyOf(ulmits);
+    public Builder ulimits(final Ulimit... ulimits) {
+      if (ulimits != null && ulimits.length > 0) {
+        this.ulimits = ImmutableList.copyOf(ulimits);
       }
 
       return this;

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -61,6 +61,9 @@ public class HostConfig {
   @JsonProperty("RestartPolicy") private RestartPolicy restartPolicy;
   @JsonProperty("LogConfig") private LogConfig logConfig;
   @JsonProperty("IpcMode") private String ipcMode;
+  // tacked on ulimit builder to support new-er docker host configs
+  @JsonProperty("Ulimits")
+  private ImmutableList<Ulimit> ulimits;
 
   private HostConfig() {
   }
@@ -91,6 +94,7 @@ public class HostConfig {
     this.restartPolicy = builder.restartPolicy;
     this.logConfig = builder.logConfig;
     this.ipcMode = builder.ipcMode;
+    this.ulimits = builder.ulimits;
   }
 
   public List<String> binds() {
@@ -407,6 +411,7 @@ public class HostConfig {
     private String networkMode;
     private ImmutableList<String> securityOpt;
     private ImmutableList<Device> devices;
+    private ImmutableList<Ulimit> ulimits;
     public Long memory;
     public Long memorySwap;
     public Long cpuShares;
@@ -416,6 +421,7 @@ public class HostConfig {
     public RestartPolicy restartPolicy;
     public LogConfig logConfig;
     public String ipcMode;
+
 
     private Builder() {
     }
@@ -446,6 +452,7 @@ public class HostConfig {
       this.restartPolicy = hostConfig.restartPolicy;
       this.logConfig = hostConfig.logConfig;
       this.ipcMode = hostConfig.ipcMode;
+      this.ulimits = hostConfig.ulimits;
     }
 
     /**
@@ -773,6 +780,25 @@ public class HostConfig {
 
     public List<Device> devices() {
       return devices;
+    }
+
+    public Builder ulimits(final List<Ulimit> ulimits) {
+      if (ulimits != null && !ulimits.isEmpty()) {
+        this.ulimits = ImmutableList.copyOf(ulimits);
+      }
+      return this;
+    }
+
+    public Builder ulimits(final Ulimit... ulmits) {
+      if (ulmits != null && ulmits.length > 0) {
+        this.ulimits = ImmutableList.copyOf(ulmits);
+      }
+
+      return this;
+    }
+
+    public List<Ulimit> ulimits() {
+      return ulimits;
     }
 
     public Builder memory(final Long memory) {

--- a/src/main/java/com/spotify/docker/client/messages/Ulimit.java
+++ b/src/main/java/com/spotify/docker/client/messages/Ulimit.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+public class Ulimit {
+    @JsonProperty("Name")
+    private String name;
+    @JsonProperty("Soft")
+    private Long soft;
+    @JsonProperty("Hard")
+    private Long hard;
+
+    public Ulimit() {
+    }
+
+    public Ulimit(final String name, final Long soft,
+                  final Long hard) {
+        this.name = name;
+        this.soft = soft;
+        this.hard = hard;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getSoft() {
+        return soft;
+    }
+
+    public Long getHard() {
+        return hard;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Ulimit that = (Ulimit) o;
+
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.soft, that.soft) &&
+                Objects.equals(this.hard, that.hard);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, soft, hard);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("name", name)
+                .add("soft", soft)
+                .add("hard", hard)
+                .toString();
+    }
+}


### PR DESCRIPTION
Rebasing the existing fork from current master branch in original project proved too tedious for the purpose of this pull request. I need to test that the addition of the Ulimit builder will work with tenzing scripts and shipyard client. Locally, I have a modified version of shipyard v3 client working that uses this branch. The tenzing scripts I modified with Ulimit objects included successfully created and started the elastic search containers in `ulvbqsrdh04.rei.com`, `ulvbqsrdh05.rei.com`, `ulvbqsrdh06.rei.com`. (_If you want to test with curl the health endpoint for elastic search would be_ `ulvbqsrdh04.rei.com/_cat/health`)